### PR TITLE
Fix bug that stopped this package from working

### DIFF
--- a/lib/markdown-preview-auto-open.coffee
+++ b/lib/markdown-preview-auto-open.coffee
@@ -38,7 +38,7 @@ module.exports = MarkdownPreviewAutoOpen =
     previewPane = atom.workspace.paneForURI(previewUrl)
 
     if not previewPane
-      workspaceView = atom.views.getView(atom.workspace)
+      workspaceView = event.item.component.element
       atom.commands.dispatch workspaceView, 'markdown-preview:toggle'
 
     if atom.config.get('markdown-preview-auto-open.closePreviewWhenClosingFile')


### PR DESCRIPTION
For some reason the previous method of opening the preview pane didn't work anymore. This method dispatches the event on the editor instead of the workspace.